### PR TITLE
Update PartyComposer to support multiple PartyTaxSchemes

### DIFF
--- a/facturark/composers/party_composer.py
+++ b/facturark/composers/party_composer.py
@@ -28,9 +28,9 @@ class PartyComposer(Composer):
             self.location_composer.compose(
                 data_dict['physical_location'], 'PhysicalLocation'))
 
-        root.append(
-            self.party_tax_scheme_composer.compose(
-                data_dict['party_tax_scheme']))
+        for party_tax_scheme_dict in data_dict['party_tax_schemes']:
+            root.append(self.party_tax_scheme_composer.compose(
+                party_tax_scheme_dict))
 
         party_legal_entity_dict = data_dict.get('party_legal_entity')
         root.append(self.party_legal_entity_composer.compose(

--- a/tests/composers/test_credit_note_composer.py
+++ b/tests/composers/test_credit_note_composer.py
@@ -37,9 +37,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -71,9 +71,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },

--- a/tests/composers/test_customer_party_composer.py
+++ b/tests/composers/test_customer_party_composer.py
@@ -35,9 +35,9 @@ def data_dict():
                     '#text':  '900555666'
                 }
             },
-            'party_tax_scheme': {
+            'party_tax_schemes': [{
                 'tax_level_code': '0'
-            },
+            }],
             'party_legal_entity': {
                 'registration_name': '800777555'
             },

--- a/tests/composers/test_debit_note_composer.py
+++ b/tests/composers/test_debit_note_composer.py
@@ -37,9 +37,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -71,9 +71,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },

--- a/tests/composers/test_delivery_composer.py
+++ b/tests/composers/test_delivery_composer.py
@@ -56,9 +56,9 @@ def data_dict():
                     '#text':  '900555666'
                 }
             },
-            'party_tax_scheme': {
+            'party_tax_schemes': [{
                 'tax_level_code': '0'
-            },
+            }],
             'party_legal_entity': {
                 'registration_name': '800777555'
             },
@@ -94,9 +94,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },

--- a/tests/composers/test_despatch_composer.py
+++ b/tests/composers/test_despatch_composer.py
@@ -44,9 +44,9 @@ def data_dict():
                     '#text':  '900555666'
                 }
             },
-            'party_tax_scheme': {
+            'party_tax_schemes': [{
                 'tax_level_code': '0'
-            },
+            }],
             'party_legal_entity': {
                 'registration_name': '800777555'
             },

--- a/tests/composers/test_invoice_composers.py
+++ b/tests/composers/test_invoice_composers.py
@@ -62,9 +62,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -96,9 +96,9 @@ def data_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },

--- a/tests/composers/test_party_composer.py
+++ b/tests/composers/test_party_composer.py
@@ -32,9 +32,11 @@ def data_dict():
                 '#text':  '900555666'
             }
         },
-        'party_tax_scheme': {
+        'party_tax_schemes': [{
             'tax_level_code': '0'
-        },
+        }, {
+            'tax_level_code': 'O-11'
+        }],
         'party_legal_entity': {
             'registration_name': '800777555'
         },

--- a/tests/composers/test_supplier_party_composer.py
+++ b/tests/composers/test_supplier_party_composer.py
@@ -35,9 +35,9 @@ def data_dict():
                     '#text':  '900555666'
                 }
             },
-            'party_tax_scheme': {
+            'party_tax_schemes': [{
                 'tax_level_code': '0'
-            },
+            }],
             'party_legal_entity': {
                 'registration_name': '800777555'
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,9 @@ def invoice_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -65,9 +65,9 @@ def invoice_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -188,9 +188,9 @@ def credit_note_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -222,9 +222,9 @@ def credit_note_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -343,9 +343,9 @@ def debit_note_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },
@@ -377,9 +377,9 @@ def debit_note_dict():
                         '#text':  '900555666'
                     }
                 },
-                'party_tax_scheme': {
+                'party_tax_schemes': [{
                     'tax_level_code': '0'
-                },
+                }],
                 'party_legal_entity': {
                     'registration_name': '800777555'
                 },


### PR DESCRIPTION
The AccountingSupplierParty and CustomerSupplierParty node have now a 'party_tax_schemes' list of dictionaries/objects attribute instead of a single dictionary. This changes enables the generation of documents with multiple PartyTaxSchemes.