### PR TITLE
[FIX] import errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     keywords='facturark',
     name='facturark',
-    packages=find_packages(include=['facturark']),
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=6.0', ]
+requirements = ['lxml>=3.7.1', 'zeep>=3.1.0', 'qrcode>=5.3', 'cryptography', 'pyOpenSSL']
 
 setup_requirements = ['pytest-runner', ]
 


### PR DESCRIPTION
find packages with include argument would only find the packages covered by
the regex of the include argument. We'd rather exclude tests and leave the rest