### PR TITLE
[FIX] include required assets (xsd & pdf)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,15 @@ setup(
     install_requires=requirements,
     license="GNU General Public License v3",
     long_description=readme + '\n\n' + history,
-    include_package_data=True,
+    package_data={
+        '': [
+            'XSD/DIAN/*.xsd',
+            'XSD/DIAN/UBL2/common/*.xsd',
+            'XSD/XADES/*.xsd',
+            'XSD/XADES/XMLDSIG/*.xsd',
+            'assets/*'
+            ],
+    },
     keywords='facturark',
     name='facturark',
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),


### PR DESCRIPTION
@tebanep 

Towards https://github.com/nubark/facturark/issues/18#issuecomment-447207172

However, I wonder why the pdf sources have to be included to calculate their hash value instead of just including the hash value. It's very transparent (and the whole truth), but maybe saving on those 2MBs would be worth a thought?